### PR TITLE
Allow user agent configuration ID:2733

### DIFF
--- a/lib/agris.rb
+++ b/lib/agris.rb
@@ -12,7 +12,12 @@ module Agris
   class UnknownError < StandardError; end
 
   class << self
-    attr_accessor :credentials, :context, :logger, :proxy_url, :request_type
+    attr_accessor :credentials,
+                  :context,
+                  :logger,
+                  :proxy_url,
+                  :request_type,
+                  :user_agent
     # ```ruby
     # Agris.configure do |config|
     #   config.credentials = Agris::Credentials::Anonymous.new
@@ -26,6 +31,7 @@ module Agris
     #   )
     #   config.request_type = Agris::SavonRequest
     #   config.logger = Logger.new(STDOUT)
+    #   config.user_agent = 'Otis'
     # end
     # ```
     # elsewhere
@@ -50,5 +56,6 @@ module Agris
   autoload :HTTPartyRequest, 'agris/httparty_request'
   autoload :ProcessMessageResponse, 'agris/process_message_response'
   autoload :SavonRequest, 'agris/savon_request'
+  autoload :UserAgent, 'agris/user_agent'
   autoload :XmlModel, 'agris/xml_model'
 end

--- a/lib/agris/api/messages/query_base.rb
+++ b/lib/agris/api/messages/query_base.rb
@@ -7,7 +7,7 @@ module Agris
 
         def input_base_hash
           {
-            :@requester => 'Agris Client',
+            :@requester => Agris::USER_AGENT,
             :@usefile => false
           }
         end

--- a/lib/agris/savon_request.rb
+++ b/lib/agris/savon_request.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'agris/user_agent'
 require 'savon'
 
 module Agris

--- a/lib/agris/user_agent.rb
+++ b/lib/agris/user_agent.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'agris/version'
+
+module Agris
+  USER_AGENT = Agris.user_agent.to_s + " (Agris.rb #{VERSION})".freeze
+end


### PR DESCRIPTION
https://westernmilling.tpondemand.com/entity/2733

Changes the requester to include a configurable string and the current `agris.rb` version.