### PR TITLE
Add apply_no field to NewTicketApplication

### DIFF
--- a/lib/agris/api/grain/new_ticket_application.rb
+++ b/lib/agris/api/grain/new_ticket_application.rb
@@ -6,6 +6,7 @@ module Agris
         include XmlModel
 
         ATTRIBUTE_NAMES = %w(
+          apply_no
           apply_type
           expected_apply_type
           apply_name_id

--- a/lib/agris/version.rb
+++ b/lib/agris/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Agris
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
apply_no field was missing from NewTicketApplication and is
needed to attach a NewTicketApplication to a contract.

Version bump to 0.2.1

needed-by westernmilling/otis#223