### PR TITLE
Support for Commodity Code endpoint

### DIFF
--- a/agris.gemspec
+++ b/agris.gemspec
@@ -29,4 +29,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '0.49.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'webmock', '~> 2.3'
+  spec.add_development_dependency 'pry-byebug'
 end

--- a/lib/agris/api/document_query_response.rb
+++ b/lib/agris/api/document_query_response.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'pry-byebug'
 module Agris
   module Api
     class DocumentQueryResponse
@@ -10,7 +11,9 @@ module Agris
 
       def last_request_date_time
         DateTime.parse(
-          @output_hash["#{resource_name}s"]['system']['lastrequestdatetime']
+          @output_hash[pluralized_resource_name] \
+                      ['system'] \
+                      ['lastrequestdatetime']
         )
       end
 
@@ -35,6 +38,10 @@ module Agris
                            .downcase
       end
 
+      def pluralized_resource_name
+        resource_type.pluralized_name
+      end
+
       def resource_type
         @resource_type ||= Object.const_get(
           self
@@ -48,7 +55,7 @@ module Agris
 
       def resources
         # Wrap and flatten for single responses
-        [@output_hash["#{resource_name}s"][resource_name]]
+        [@output_hash[pluralized_resource_name][resource_name]]
           .compact
           .flatten
       end

--- a/lib/agris/api/document_query_response.rb
+++ b/lib/agris/api/document_query_response.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require 'pry-byebug'
 module Agris
   module Api
     class DocumentQueryResponse

--- a/lib/agris/api/grain.rb
+++ b/lib/agris/api/grain.rb
@@ -2,11 +2,15 @@
 module Agris
   module Api
     module Grain
+      autoload :Commodity, 'agris/api/grain/commodity'
+      autoload :CommodityCodes, 'agris/api/grain/commodity_codes'
       autoload :Contract, 'agris/api/grain/contract'
       autoload :PurchaseContracts, 'agris/api/grain/purchase_contracts'
       autoload :NewTicket, 'agris/api/grain/new_ticket'
       autoload :NewTicketApplication, 'agris/api/grain/new_ticket_application'
       autoload :NewTicketRemark, 'agris/api/grain/new_ticket_remark'
+      autoload :SpecificCommodityCodeExtract,
+               'agris/api/grain/specific_commodity_code_extract'
       autoload :SpecificPurchaseContractExtract,
                'agris/api/grain/specific_purchase_contract_extract'
       autoload :Tickets,

--- a/lib/agris/api/grain/commodity.rb
+++ b/lib/agris/api/grain/commodity.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+module Agris
+  module Api
+    module Grain
+      class Commodity
+        include XmlModel
+
+        ATTRIBUTE_NAMES = %w(
+          unique_id
+          integration_guid
+          location
+          location_description
+          code
+          code_description
+          dpr_by_variety_class
+          buy_sell_uom_code
+          buy_sell_uom
+          inv_buy_sell_uom_code
+          inv_buy_sell_uom_code_desc
+          position_uom
+          ledger_uom
+          buy_sell_weight_factor
+          position_weight_factor
+          ledger_weight_factor
+          status
+          status_description
+          hedgeable
+          valid_future_month
+          nearby_future_month
+          default_future_month
+          default_board_name
+          inbound_freight_account
+          inbound_freight_account_desc
+          outbound_freight_account
+          outbound_freight_account_desc
+          ar_invoice_type
+          ar_invoice_type_desc
+          position_report_field_1
+          position_report_field_2
+          ap_voucher_type
+          ap_voucher_type_desc
+          taxable_1
+          taxable_2
+          taxable_3
+          taxable_4
+          inbound_adjust_prcnt
+          outbound_adjust_prcnt
+          minimum_price
+          maximum_price
+          cash_price
+          cash_basis
+          freight_tax_percent
+          hedge_percent
+          uom_product_group
+          uom_product_group_description
+          delete
+          lastchangedatetime
+          last_change_user_id
+          last_change_user_name
+        ).freeze
+
+        attr_reader(*ATTRIBUTE_NAMES)
+      end
+    end
+  end
+end

--- a/lib/agris/api/grain/commodity.rb
+++ b/lib/agris/api/grain/commodity.rb
@@ -5,6 +5,10 @@ module Agris
       class Commodity
         include XmlModel
 
+        def self.pluralized_name
+          'commodities'
+        end
+
         ATTRIBUTE_NAMES = %w(
           unique_id
           integration_guid

--- a/lib/agris/api/grain/commodity_codes.rb
+++ b/lib/agris/api/grain/commodity_codes.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+module Agris
+  module Api
+    module Grain
+      module CommodityCodes
+        def commodity_code(location, code)
+          extract = Agris::Api::Grain::SpecificCommodityCodeExtract
+                    .new(location, code)
+
+          commodity_codes([extract])
+        end
+
+        def commodity_codes(extracts)
+          extract_documents(
+            Messages::QueryCommodityCodeDocuments.new(extracts),
+            Agris::Api::Grain::Commodity
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/agris/api/grain/specific_commodity_code_extract.rb
+++ b/lib/agris/api/grain/specific_commodity_code_extract.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+module Agris
+  module Api
+    module Grain
+      class SpecificCommodityCodeExtract
+        include ::Agris::XmlModel
+
+        attr_accessor :location, :code
+
+        def initialize(location, code)
+          @location = location
+          @code = code
+        end
+      end
+    end
+  end
+end

--- a/lib/agris/api/messages.rb
+++ b/lib/agris/api/messages.rb
@@ -2,6 +2,8 @@
 module Agris
   module Api
     module Messages
+      autoload :DocumentQueryBase,
+               'agris/api/messages/document_query_base'
       autoload :MessageBase,
                'agris/api/messages/message_base'
       autoload :Import,

--- a/lib/agris/api/messages.rb
+++ b/lib/agris/api/messages.rb
@@ -8,6 +8,8 @@ module Agris
                'agris/api/messages/import'
       autoload :QueryBase,
                'agris/api/messages/query_base'
+      autoload :QueryCommodityCodeDocuments,
+               'agris/api/messages/query_commodity_code_documents'
       autoload :QueryChangedDeliveryTickets,
                'agris/api/messages/query_changed_delivery_tickets'
       autoload :QueryChangedPurchaseContracts,

--- a/lib/agris/api/messages/document_query_base.rb
+++ b/lib/agris/api/messages/document_query_base.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+module Agris
+  module Api
+    module Messages
+      class DocumentQueryBase < QueryBase
+        def initialize(document_references)
+          @document_references = document_references
+        end
+
+        protected
+
+        def input_hash
+          input_base_hash
+        end
+      end
+    end
+  end
+end

--- a/lib/agris/api/messages/query_commodity_code_documents.rb
+++ b/lib/agris/api/messages/query_commodity_code_documents.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+module Agris
+  module Api
+    module Messages
+      class QueryCommodityCodeDocuments < QueryBase
+        def initialize(document_references)
+          @document_references = document_references
+        end
+
+        def message_number
+          81_300
+        end
+
+        protected
+
+        def input_hash
+          input_base_hash
+        end
+
+        def xml_hash
+          xml_base_hash
+            .merge(
+              commodity: @document_references.map(&:to_xml_hash)
+            )
+        end
+      end
+    end
+  end
+end

--- a/lib/agris/api/messages/query_commodity_code_documents.rb
+++ b/lib/agris/api/messages/query_commodity_code_documents.rb
@@ -2,20 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryCommodityCodeDocuments < QueryBase
-        def initialize(document_references)
-          @document_references = document_references
-        end
-
+      class QueryCommodityCodeDocuments < DocumentQueryBase
         def message_number
           81_300
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/api/messages/query_delivery_ticket_documents.rb
+++ b/lib/agris/api/messages/query_delivery_ticket_documents.rb
@@ -2,20 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryDeliveryTicketDocuments < QueryBase
-        def initialize(document_references)
-          @document_references = document_references
-        end
-
+      class QueryDeliveryTicketDocuments < DocumentQueryBase
         def message_number
           80_600
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/api/messages/query_invoice_documents.rb
+++ b/lib/agris/api/messages/query_invoice_documents.rb
@@ -2,20 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryInvoiceDocuments < QueryBase
-        def initialize(document_references)
-          @document_references = document_references
-        end
-
+      class QueryInvoiceDocuments < DocumentQueryBase
         def message_number
           80_500
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/api/messages/query_order_documents.rb
+++ b/lib/agris/api/messages/query_order_documents.rb
@@ -2,20 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryOrderDocuments < QueryBase
-        def initialize(document_references)
-          @document_references = document_references
-        end
-
+      class QueryOrderDocuments < DocumentQueryBase
         def message_number
           80_900
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/api/messages/query_purchase_contract_documents.rb
+++ b/lib/agris/api/messages/query_purchase_contract_documents.rb
@@ -2,20 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryPurchaseContractDocuments < QueryBase
-        def initialize(document_references)
-          @document_references = document_references
-        end
-
+      class QueryPurchaseContractDocuments < DocumentQueryBase
         def message_number
           80_150
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/client.rb
+++ b/lib/agris/client.rb
@@ -3,6 +3,7 @@ module Agris
   class Client
     include Api::AccountsPayables::Vouchers
     include Api::AccountsReceivables::Invoices
+    include Api::Grain::CommodityCodes
     include Api::Grain::PurchaseContracts
     include Api::Grain::Tickets
     include Api::Inventory::DeliveryTickets

--- a/lib/agris/version.rb
+++ b/lib/agris/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Agris
-  VERSION = '0.2.1'
+  VERSION = '0.3.0'
 end

--- a/lib/agris/xml_model.rb
+++ b/lib/agris/xml_model.rb
@@ -58,6 +58,10 @@ module Agris
 
         klass.new(translated_hash)
       end
+
+      def pluralized_name
+        "#{name.split('::').last.downcase}s"
+      end
     end
   end
 end

--- a/spec/fixtures/agris/grain/commodity_code_not_found_response.xml
+++ b/spec/fixtures/agris/grain/commodity_code_not_found_response.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessMessageResponse xmlns="http://www.deere.com/agriservices/">
+      <ProcessMessageResult>true</ProcessMessageResult>
+      <AgOutput_obj_p>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;commodities&gt;&lt;system message="81300" package="GRN" messageversion="18.2.0" lastrequestdatetime="" filename="" systemversion="18.2.0" systemid="G7" componentserver="APP510-STG-GSH"
+        dbservername="stg" dbname="AGRIS" datapath="\\stg\apps\agris\datasets\001" datasetnumber="001" datasetdescription="Dataset 1" datasetid="BWO" datasetguid="441BC291-951E-4F23-84B8-4770993E6F11"
+        licenseguid="12312123-5801-4698-AD4F-62132132FAD" count="0" startdatetime="2018-05-15T08:36:09" enddatetime="2018-05-15T08:36:09" elapsemillisecond="219" /&gt;&lt;/commodities&gt;</AgOutput_obj_p>
+    </ProcessMessageResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/fixtures/agris/grain/commodity_code_one_response.xml
+++ b/spec/fixtures/agris/grain/commodity_code_one_response.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessMessageResponse xmlns="http://www.deere.com/agriservices/">
+      <ProcessMessageResult>true</ProcessMessageResult>
+      <AgOutput_obj_p>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;commodities&gt;&lt;system message="81300" package="GRN" messageversion="18.2.0" lastrequestdatetime="" filename="" systemversion="18.2.0" systemid="G7" componentserver="stg"
+        dbservername="stg" dbname="AGRIS" datapath="\\stg\apps\agris\datasets\001" datasetnumber="001" datasetdescription="Dataset 1" datasetid="BWO" datasetguid="111BC291-AA1E-4F9B-ACB8-4770993E6F09"
+        licenseguid="111A6F97-5AA1-1298-AD4F-111CED9AAFAD" count="1" startdatetime="2018-05-15T08:36:45" enddatetime="2018-05-15T08:36:45" elapsemillisecond="219" /&gt;&lt;commodity uniqueid="GRN:GNCOM:AAA:WD:" integrationguid="" location="AAA"
+        locationdescription="XYZ Inventory" code="WD" codedescription="Wheat,Durum" dprbyvarietyclass="N" buyselluomcode="BU" buyselluom="Bushels" invbuyselluomcode="BU60" invbuyselluomcodedesc="Bushel 60" positionuom="Tons" ledgeruom="Tons"
+        buysellweightfactor="60" positionweightfactor="2000" ledgerweightfactor="2000" status="A" statusdescription="Active" hedgeable="Y" validfuturemonth="NNYNYNYNYNNY" nearbyfuturemonth="" defaultfuturemonth="" defaultboardname=""
+        inboundfreightaccount="45000 WD WHT" inboundfreightaccountdesc="COGS Comm Wheat" outboundfreightaccount="40000 WD WHT" outboundfreightaccountdesc="Sale Comm Wheat" arinvoicetype="GI" arinvoicetypedesc="Grain Invoice" positionreportfield1=""
+        positionreportfield2="Wheat" apvouchertype="GV" apvouchertypedesc="Grain Voucher" taxable1="N" taxable2="N" taxable3="N" taxable4="N" inboundadjustprcnt="0" outboundadjustprcnt="0" minimumprice="0" maximumprice="0" cashprice="1.0" cashbasis="0"
+        freighttaxpercent="0" hedgepercent="0" uomproductgroup="" uomproductgroupdescription="" defaultboarddesc="" cashpricecurrency="" cashpricecurrencydesc="" tradinglimit="0" delete="false" lastchangedatetime="" lastchangeuserid=""
+        lastchangeusername=""&gt;&lt;discounts&gt;&lt;discount number="1" code="PR" description="Protein" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="4"
+        /&gt;&lt;discount number="2" code="DG" description="Dockage" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="1" /&gt;&lt;discount number="3" code="TW"
+        description="Test Weight" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="1" /&gt;&lt;discount number="4" code="MO" description="Moisture" gradedefault="0"
+        grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="5" /&gt;&lt;discount number="5" code="SK" description="Shrunken/Bkn Kernels" gradedefault="0" grademinimum="0"
+        grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="6" /&gt;&lt;discount number="6" code="FM" description="Foreign Materials" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable=""
+        inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="7" /&gt;&lt;discount number="7" code="HV" description="Hard Vitreous Amber Color" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc=""
+        outboundtable="" outboundtabledesc="" calculationorder="8" /&gt;&lt;discount number="8" code="DM" description="Damage" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc=""
+        calculationorder="9" /&gt;&lt;discount number="9" code="US" description="U.S. Grade" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="10" /&gt;&lt;discount
+        number="10" code="DH" description="Dockage Percent" gradedefault="0" grademinimum="0" grademaximum="0" inboundtable="" inboundtabledesc="" outboundtable="" outboundtabledesc="" calculationorder="2" /&gt;&lt;discount number="34" code="FC"
+        description="Freight Charge" gradedefault="" grademinimum="" grademaximum="" inboundtable="N" inboundtabledesc="DON'T CHARGE FREIGHT" outboundtable="N" outboundtabledesc="DON'T CHARGE FREIGHT" calculationorder="34"
+        /&gt;&lt;/discounts&gt;&lt;/commodity&gt;&lt;/commodities&gt;</AgOutput_obj_p>
+    </ProcessMessageResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/lib/agris/client/grain/commodity_codes_spec.rb
+++ b/spec/lib/agris/client/grain/commodity_codes_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'savon/mock/spec_helper'
+require_relative '../shared_contexts'
+
+describe Agris::Client, :agris_api_mock do
+  include Savon::SpecHelper
+
+  describe '#commodity_code' do
+    include_context 'test agris client'
+
+    before do
+      savon
+        .expects(:process_message)
+        .with(message: :any)
+        .returns(response_body)
+    end
+
+    let(:response_body) do
+      File.read(File.join(%W(./ spec fixtures agris #{fixture_file})))
+    end
+
+    context 'when a commodity is found' do
+      let(:fixture_file) { 'grain/commodity_code_one_response.xml' }
+      let(:location) { 'ABC' }
+      let(:code) { 'WD' }
+
+      it 'returns the contract' do
+        result = client.commodity_code(location, code)
+
+        expect(result.documents.length).to eq(1)
+        expect(result.documents[0].code).to eq(code)
+      end
+    end
+
+    context 'when a commodity is not found' do
+      let(:fixture_file) { 'grain/commodity_code_not_found_response.xml' }
+      let(:location) { 'ABC' }
+      let(:code) { '1' }
+
+      it 'returns no commodity' do
+        result = client.commodity_code(location, code)
+
+        expect(result.documents.length).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Add support for retrieving records from the commodity code
endpoint. This allows us to get the weight in pounds for
commodities that use volume like bushels in contracts for them.

Add pry-byebug for quick step through debugging with syntax
highlighting.

Verison bump to `0.3.0`

needed-by westernmilling/otis#287