### PR TITLE
Option to retrieve changed orders with no details

### DIFF
--- a/lib/agris/api/inventory/orders.rb
+++ b/lib/agris/api/inventory/orders.rb
@@ -28,9 +28,9 @@ module Agris
           )
         end
 
-        def orders_changed_since(datetime)
+        def orders_changed_since(datetime, detail = false)
           extract_documents(
-            Messages::QueryChangedOrders.new(datetime),
+            Messages::QueryChangedOrders.new(datetime, detail),
             Agris::Api::Order
           )
         end

--- a/lib/agris/api/messages/query_changed_orders.rb
+++ b/lib/agris/api/messages/query_changed_orders.rb
@@ -3,8 +3,9 @@ module Agris
   module Api
     module Messages
       class QueryChangedOrders < QueryBase
-        def initialize(time)
+        def initialize(time, detail)
           @time = time
+          @detail = detail
         end
 
         def message_number
@@ -16,6 +17,7 @@ module Agris
         def input_hash
           input_base_hash
             .merge(
+              :@details => @detail,
               locid: {
                 :@datetime => @time.strftime('%Y-%m-%dT%H:%M:%S'),
                 :@id => nil,

--- a/spec/fixtures/agris/inventory/order_not_found_result.xml
+++ b/spec/fixtures/agris/inventory/order_not_found_result.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessMessageResponse xmlns="http://www.deere.com/agriservices/">
+      <ProcessMessageResult>true</ProcessMessageResult>
+      <AgOutput_obj_p>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;orders&gt;&lt;system message="80900" package="INV" messageversion="18.2.0" lastrequestdatetime="2018-05-23T14:43:55" filename="" systemversion="18.2.0" systemid="AA"
+        componentserver="SERVER" dbservername="server" dbname="AGRIS" datapath="\\server\apps\AGRIS\datasets\001" datasetnumber="001" datasetdescription="TEST" datasetid="AAA"
+        datasetguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" licenseguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" count="0" startdatetime="2018-05-23T14:43:53" enddatetime="2018-05-23T14:43:56" elapsemillisecond="2765" /&gt;&lt;/orders&gt;</AgOutput_obj_p><AgError_str_p/></ProcessMessageResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/fixtures/agris/inventory/orders_two_results_no_detail.xml
+++ b/spec/fixtures/agris/inventory/orders_two_results_no_detail.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessMessageResponse xmlns="http://www.deere.com/agriservices/">
+      <ProcessMessageResult>true</ProcessMessageResult>
+      <AgOutput_obj_p>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;orders&gt;&lt;system message="80900" package="INV" messageversion="18.2.0" lastrequestdatetime="2018-05-23T14:54:25" filename="" systemversion="18.2.0" systemid="AA"
+        componentserver="SERVER" dbservername="server" dbname="AGRIS" datapath="\\server\apps\AGRIS\datasets\001" datasetnumber="001" datasetdescription="STAGING" datasetid="AAA"
+        datasetguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" licenseguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" count="2" startdatetime="2018-05-23T14:54:24" enddatetime="2018-05-23T14:54:28" elapsemillisecond="4171" /&gt;&lt;order
+        uniqueid="INV:SORDR:AAA:000001:1000000-00" integrationguid="" ordertype="S" orderlocation="AAA" ordernumber="000001" shiptofromid="1000000-00" delete="false" /&gt;&lt;order uniqueid="INV:SORDR:AAA:000002:1000000-01" integrationguid="" ordertype="S"
+        orderlocation="AAA" ordernumber="000002" shiptofromid="1000000-01" delete="false" /&gt;
+        &lt;/orders&gt;</AgOutput_obj_p><AgError_str_p/></ProcessMessageResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/lib/agris/client/inventory/orders_spec.rb
+++ b/spec/lib/agris/client/inventory/orders_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'savon/mock/spec_helper'
+require_relative '../shared_contexts'
+
+describe Agris::Client, :agris_api_mock do
+  include Savon::SpecHelper
+
+  describe '#orders_changed_since' do
+    include_context 'test agris client'
+
+    before do
+      savon
+        .expects(:process_message)
+        .with(message: :any)
+        .returns(response_body)
+    end
+
+    let(:response_body) do
+      File.read(File.join(%W(./ spec fixtures agris #{fixture_file})))
+    end
+    let(:datetime) { Time.parse('2018-01-03T14:25:00)') }
+
+    context 'when orders are returned' do
+      let(:fixture_file) do
+        'inventory/orders_two_results_no_detail.xml'
+      end
+      let(:order_number_1) { '000001' }
+      let(:order_number_2) { '000002' }
+
+      it 'returns the orders' do
+        result = client.orders_changed_since(datetime)
+
+        expect(result.documents.length).to eq(2)
+        expect(result.documents[0].order_number).to eq(order_number_1)
+        expect(result.documents[1].order_number).to eq(order_number_2)
+      end
+    end
+
+    context 'when a contract is not found' do
+      let(:fixture_file) { 'inventory/order_not_found_result.xml' }
+
+      it 'returns no contract' do
+        result = client.orders_changed_since(datetime)
+
+        expect(result.documents.length).to eq(0)
+      end
+    end
+  end
+end

--- a/spec/lib/agris/client/inventory/orders_spec.rb
+++ b/spec/lib/agris/client/inventory/orders_spec.rb
@@ -37,10 +37,10 @@ describe Agris::Client, :agris_api_mock do
       end
     end
 
-    context 'when a contract is not found' do
+    context 'when no orders are found' do
       let(:fixture_file) { 'inventory/order_not_found_result.xml' }
 
-      it 'returns no contract' do
+      it 'returns no order' do
         result = client.orders_changed_since(datetime)
 
         expect(result.documents.length).to eq(0)


### PR DESCRIPTION
Change orders_changed_since call to accept an attribute for
asking Agris for details or not. This supports Otis grabbing all
changed orders without details to speed up calls when a large
number of orders have changed. And to ensure each order is up to
date when processed by grabbing the details then.

needed-by westernmilling/otis#293