### PR TITLE
Option to retrieve changed delivery tickets with no details

### DIFF
--- a/lib/agris/api/inventory/delivery_tickets.rb
+++ b/lib/agris/api/inventory/delivery_tickets.rb
@@ -18,9 +18,9 @@ module Agris
           )
         end
 
-        def delivery_tickets_changed_since(datetime)
+        def delivery_tickets_changed_since(datetime, detail = false)
           extract_documents(
-            Messages::QueryChangedDeliveryTickets.new(datetime),
+            Messages::QueryChangedDeliveryTickets.new(datetime, detail),
             DeliveryTicket
           )
         end

--- a/lib/agris/api/messages.rb
+++ b/lib/agris/api/messages.rb
@@ -2,6 +2,8 @@
 module Agris
   module Api
     module Messages
+      autoload :ChangedQueryBase,
+               'agris/api/messages/changed_query_base'
       autoload :DocumentQueryBase,
                'agris/api/messages/document_query_base'
       autoload :MessageBase,

--- a/lib/agris/api/messages/changed_query_base.rb
+++ b/lib/agris/api/messages/changed_query_base.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+module Agris
+  module Api
+    module Messages
+      class ChangedQueryBase < QueryBase
+        def initialize(time, detail)
+          @time = time
+          @detail = detail
+        end
+
+        protected
+
+        def input_hash
+          input_base_hash
+            .merge(
+              :@details => @detail,
+              locid: {
+                :@datetime => @time.strftime('%Y-%m-%dT%H:%M:%S'),
+                :@id => nil,
+                :@loccode => nil
+              }
+            )
+        end
+      end
+    end
+  end
+end

--- a/lib/agris/api/messages/query_changed_delivery_tickets.rb
+++ b/lib/agris/api/messages/query_changed_delivery_tickets.rb
@@ -2,29 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryChangedDeliveryTickets < QueryBase
-        def initialize(time, detail)
-          @time = time
-          @detail = detail
-        end
-
+      class QueryChangedDeliveryTickets < ChangedQueryBase
         def message_number
           80_600
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-            .merge(
-              :@details => @detail,
-              locid: {
-                :@datetime => @time.strftime('%Y-%m-%dT%H:%M:%S'),
-                :@id => nil,
-                :@loccode => nil
-              }
-            )
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/api/messages/query_changed_delivery_tickets.rb
+++ b/lib/agris/api/messages/query_changed_delivery_tickets.rb
@@ -3,8 +3,9 @@ module Agris
   module Api
     module Messages
       class QueryChangedDeliveryTickets < QueryBase
-        def initialize(time)
+        def initialize(time, detail)
           @time = time
+          @detail = detail
         end
 
         def message_number
@@ -16,6 +17,7 @@ module Agris
         def input_hash
           input_base_hash
             .merge(
+              :@details => @detail,
               locid: {
                 :@datetime => @time.strftime('%Y-%m-%dT%H:%M:%S'),
                 :@id => nil,

--- a/lib/agris/api/messages/query_changed_invoices.rb
+++ b/lib/agris/api/messages/query_changed_invoices.rb
@@ -2,29 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryChangedInvoices < QueryBase
-        def initialize(time, detail)
-          @time = time
-          @detail = detail
-        end
-
+      class QueryChangedInvoices < ChangedQueryBase
         def message_number
           80_500
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-            .merge(
-              :@details => @detail,
-              locid: {
-                :@datetime => @time.strftime('%Y-%m-%dT%H:%M:%S'),
-                :@id => nil,
-                :@loccode => nil
-              }
-            )
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/api/messages/query_changed_orders.rb
+++ b/lib/agris/api/messages/query_changed_orders.rb
@@ -2,29 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryChangedOrders < QueryBase
-        def initialize(time, detail)
-          @time = time
-          @detail = detail
-        end
-
+      class QueryChangedOrders < ChangedQueryBase
         def message_number
           80_900
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-            .merge(
-              :@details => @detail,
-              locid: {
-                :@datetime => @time.strftime('%Y-%m-%dT%H:%M:%S'),
-                :@id => nil,
-                :@loccode => nil
-              }
-            )
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/api/messages/query_changed_purchase_contracts.rb
+++ b/lib/agris/api/messages/query_changed_purchase_contracts.rb
@@ -2,29 +2,12 @@
 module Agris
   module Api
     module Messages
-      class QueryChangedPurchaseContracts < QueryBase
-        def initialize(time, detail)
-          @time = time
-          @detail = detail
-        end
-
+      class QueryChangedPurchaseContracts < ChangedQueryBase
         def message_number
           80_150
         end
 
         protected
-
-        def input_hash
-          input_base_hash
-            .merge(
-              :@details => @detail,
-              locid: {
-                :@datetime => @time.strftime('%Y-%m-%dT%H:%M:%S'),
-                :@id => nil,
-                :@loccode => nil
-              }
-            )
-        end
 
         def xml_hash
           xml_base_hash

--- a/lib/agris/version.rb
+++ b/lib/agris/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Agris
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end

--- a/spec/fixtures/agris/inventory/delivery_ticket_not_found_result.xml
+++ b/spec/fixtures/agris/inventory/delivery_ticket_not_found_result.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessMessageResponse xmlns="http://www.deere.com/agriservices/">
+      <ProcessMessageResult>true</ProcessMessageResult>
+      <AgOutput_obj_p>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;deliverytickets&gt;&lt;system message="80600" package="INV" messageversion="18.2.0" lastrequestdatetime="2018-05-23T18:43:32" filename="" systemversion="18.2.0" systemid="AA"
+        componentserver="SERVER" dbservername="app510-qa-gsh" dbname="AGRIS" datapath="\\server\apps\AGRIS\datasets\001" datasetnumber="001" datasetdescription="staging" datasetid="AAA"
+        datasetguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" licenseguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" count="0" startdatetime="2018-05-23T18:43:31" enddatetime="2018-05-23T18:43:33" elapsemillisecond="2625" /&gt;&lt;/deliverytickets&gt;</AgOutput_obj_p><AgError_str_p/></ProcessMessageResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/fixtures/agris/inventory/delivery_tickets_two_results_no_detail.xml
+++ b/spec/fixtures/agris/inventory/delivery_tickets_two_results_no_detail.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+  <soap:Body>
+    <ProcessMessageResponse xmlns="http://www.deere.com/agriservices/">
+      <ProcessMessageResult>true</ProcessMessageResult>
+      <AgOutput_obj_p>&lt;?xml version="1.0" encoding="UTF-8"?&gt;&lt;deliverytickets&gt;&lt;system message="80600" package="INV" messageversion="18.2.0" lastrequestdatetime="2018-05-23T18:38:21" filename="" systemversion="18.2.0" systemid="AA"
+        componentserver="SERVER" dbservername="server" dbname="AGRIS" datapath="\\server\apps\AGRIS\datasets\001" datasetnumber="001" datasetdescription="staging" datasetid="AAA"
+        datasetguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" licenseguid="AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA" count="2" startdatetime="2018-05-23T18:38:19" enddatetime="2018-05-23T18:38:21" elapsemillisecond="1906" /&gt;&lt;deliveryticket
+        uniqueid="INV:DTCKT:AAA:000001:1000000-01" ticketlocation="AAA" ticketnumber="000001" shiptoid="1000000-01" delete="false" integrationguid=""&gt;&lt;/deliveryticket&gt;&lt;deliveryticket uniqueid="INV:DTCKT:AAA:000002:1000000-01" ticketlocation="AAA"
+        ticketnumber="000002" shiptoid="1000000-01" delete="false" integrationguid=""&gt;&lt;/deliveryticket&gt;&lt;/deliverytickets&gt;</AgOutput_obj_p><AgError_str_p/></ProcessMessageResponse>
+  </soap:Body>
+</soap:Envelope>

--- a/spec/lib/agris/client/inventory/delivery_tickets_spec.rb
+++ b/spec/lib/agris/client/inventory/delivery_tickets_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+require 'spec_helper'
+require 'savon/mock/spec_helper'
+require_relative '../shared_contexts'
+
+describe Agris::Client, :agris_api_mock do
+  include Savon::SpecHelper
+
+  describe '#delivery_tickets_changed_since' do
+    include_context 'test agris client'
+
+    before do
+      savon
+        .expects(:process_message)
+        .with(message: :any)
+        .returns(response_body)
+    end
+
+    let(:response_body) do
+      File.read(File.join(%W(./ spec fixtures agris #{fixture_file})))
+    end
+    let(:datetime) { Time.parse('2018-01-03T14:25:00)') }
+
+    context 'when delivery_tickets are returned' do
+      let(:fixture_file) do
+        'inventory/delivery_tickets_two_results_no_detail.xml'
+      end
+      let(:ticket_number_1) { '000001' }
+      let(:ticket_number_2) { '000002' }
+
+      it 'returns the delivery_tickets' do
+        result = client.delivery_tickets_changed_since(datetime)
+
+        expect(result.documents.length).to eq(2)
+        expect(result.documents[0].ticket_number).to eq(ticket_number_1)
+        expect(result.documents[1].ticket_number).to eq(ticket_number_2)
+      end
+    end
+
+    context 'when no delivery_tickets are found' do
+      let(:fixture_file) { 'inventory/delivery_ticket_not_found_result.xml' }
+
+      it 'returns no delivery_ticket' do
+        result = client.delivery_tickets_changed_since(datetime)
+
+        expect(result.documents.length).to eq(0)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Change delivery_tickets_changed_since call to accept an attribute
for asking Agris for details or not. This supports Otis grabbing
all changed delivery tickets without details to speed up calls
when a large number of delivery tickets have changed. And to
ensure each delivery ticket is up to date when processed by
grabbing the details then.

Version bump to 0.3.1

needed-by westernmilling/otis#293