### PR TITLE
Add GlobalId to XmlModel

### DIFF
--- a/agris.gemspec
+++ b/agris.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'globalid', '~> 0.4'
   spec.add_dependency 'savon', '~> 2.11'
 
   spec.add_development_dependency 'bundler', '~> 1.14'

--- a/lib/agris/xml_model.rb
+++ b/lib/agris/xml_model.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+require 'globalid'
+
 module Agris
   module XmlModel
+    include GlobalID::Identification
+
     def self.included(base)
       base.send :include, InstanceMethods
       base.extend ClassMethods
@@ -8,6 +12,10 @@ module Agris
 
     module InstanceMethods
       attr_reader :hash
+
+      def id
+        @id = SecureRandom.uuid
+      end
 
       def attributes
         (instance_variables - [:@hash]).each_with_object({}) do |ivar, new_hash|
@@ -40,6 +48,12 @@ module Agris
     end
 
     module ClassMethods
+      def xml_class
+        Object.const_get(name)
+      end
+
+      def find(id) end
+
       def from_xml_hash(hash)
         klass = Object.const_get(name)
 

--- a/spec/lib/agris/xml_model_spec.rb
+++ b/spec/lib/agris/xml_model_spec.rb
@@ -33,4 +33,20 @@ describe Agris::XmlModel do
       expect(subject).to_not include(:@excludedattribute)
     end
   end
+
+  describe '#id' do
+    subject { TestModel.new }
+
+    it 'should return an id' do
+      expect(subject.id).not_to be_empty
+    end
+  end
+
+  describe '#id' do
+    subject { TestModel }
+
+    it 'should return Class' do
+      expect(subject.xml_class).to eq(TestModel)
+    end
+  end
 end


### PR DESCRIPTION
This was added to provide the ability to for the objects to be serialized by ActiveJob

For https://github.com/westernmilling/otis/issues/287