### PR TITLE
Pass along salesperson and merchandiser information from transcode

### DIFF
--- a/lib/agris/api/grain/contract.rb
+++ b/lib/agris/api/grain/contract.rb
@@ -73,7 +73,8 @@ module Agris
                 [hash['schedules']['schedule']]
                   .flatten
                   .map do |schedule|
-                    Schedule.from_xml_hash(schedule)
+                    enhanced_schedule = add_transcodes_to_schedule(schedule)
+                    Schedule.from_xml_hash(enhanced_schedule)
                   end
               )
             end
@@ -96,6 +97,17 @@ module Agris
           super
 
           @schedules = []
+        end
+
+        # This adds the transcode attributes like salesperson into the schedule
+        def self.add_transcodes_to_schedule(schedule)
+          schedule['trancodes']['trancode'].each do |trancode|
+            label_code = trancode['label'].downcase + 'code'
+            schedule[label_code] = trancode['code']
+            label_description = trancode['label'].downcase + 'description'
+            schedule[label_description] = trancode['description']
+          end
+          schedule
         end
 
         class Schedule
@@ -227,6 +239,10 @@ module Agris
             variety
             class
             variety_description
+            salesperson_code
+            salesperson_description
+            merchandiser_code
+            merchandiser_description
           ).freeze
 
           attr_reader(*ATTRIBUTE_NAMES)

--- a/lib/agris/version.rb
+++ b/lib/agris/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Agris
-  VERSION = '0.4.0'
+  VERSION = '0.4.1'
 end

--- a/spec/lib/agris/client/grain/purchase_contracts_spec.rb
+++ b/spec/lib/agris/client/grain/purchase_contracts_spec.rb
@@ -82,6 +82,8 @@ describe Agris::Client, :agris_api_mock do
         expect(result.documents.length).to eq(2)
         expect(result.documents[0].contract_number).to eq(contract_number_1)
         expect(result.documents[1].contract_number).to eq(contract_number_2)
+        expect(result.documents[1].schedules[0].salesperson_code).to \
+          eq('001')
       end
     end
   end


### PR DESCRIPTION
Salesperson and merchandiser information is attached to the
contract schedule's transcodes. Flatten this onto the schedule
so that library consumers can easily access them.

needed-by westernmilling/otis#428