### PR TITLE
Add ability to pass in savon log level

### DIFF
--- a/lib/agris.rb
+++ b/lib/agris.rb
@@ -14,6 +14,7 @@ module Agris
     attr_accessor :credentials,
                   :context,
                   :logger,
+                  :log_level,
                   :proxy_url,
                   :request_type,
                   :user_agent

--- a/lib/agris/client.rb
+++ b/lib/agris/client.rb
@@ -22,11 +22,12 @@ module Agris
     )
       @context = context
       @logger = options[:logger] || Agris.logger
+      @log_level = options[:log_level] || Agris.log_level
       @request_type = options[:request_type] || Agris.request_type
       @proxy_url = options.fetch(:proxy_url, Agris.proxy_url)
       @dataset = dataset || Agris.context.default_dataset
       @request = @request_type.new(
-        @context.base_url, credentials, @logger, @proxy_url
+        @context.base_url, credentials, @logger, @log_level, @proxy_url
       )
     end
 

--- a/lib/agris/savon_request.rb
+++ b/lib/agris/savon_request.rb
@@ -4,10 +4,11 @@ require 'savon'
 
 module Agris
   class SavonRequest
-    def initialize(base_url, credentials, logger, proxy_url = nil)
+    def initialize(base_url, credentials, logger, log_level, proxy_url = nil)
       @base_url = base_url
       @credentials = credentials
       @logger = logger
+      @log_level = log_level
       @proxy_url = proxy_url
     end
 
@@ -45,7 +46,7 @@ module Agris
         raise_errors: false,
         logger: @logger,
         log: true,
-        log_level: :debug
+        log_level: @log_level || :debug
       }
       options = options.merge(proxy: @proxy_url) unless @proxy_url.to_s == ''
       options = @credentials.apply(options)

--- a/lib/agris/version.rb
+++ b/lib/agris/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Agris
-  VERSION = '0.4.9'
+  VERSION = '0.4.10'
 end


### PR DESCRIPTION
This allows us to us info instead of debug on production
greatly reducing our log useage. Currently those debug logs
are not being used and when we have issues we reproduce the
request to get other information not included in the log.

needed-by [OTTO-156]