### PR TITLE
ci(circleci): unblock the build + bump to 0.20.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,17 +19,10 @@ jobs:
             gem install bundler -v '~> 2.3.7' --no-document
             bundle _2.3.27_ install --jobs=4 --retry=3 --path vendor/bundle
 
-      - run:
-          name: Setup Code Climate test-reporter
-          command: |
-            curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-            chmod +x ./cc-test-reporter
-
       # run tests!
       - run:
           name: run tests
           command: |
-            ./cc-test-reporter before-build
             mkdir /tmp/test-results
             TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
 
@@ -39,7 +32,6 @@ jobs:
               --format progress \
               -- \
               $TEST_FILES
-            ./cc-test-reporter after-build --coverage-input-type simplecov --exit-code $?
 
       # collect reports
       - store_test_results:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,16 +8,19 @@ jobs:
 
     working_directory: ~/agris
 
+    # The circleci/ruby:2.4.1 image ships Bundler 1.15.4, but the gemspec
+    # requires bundler ~> 2.3.7. BUNDLER_VERSION makes every `bundle` call
+    # in every step use 2.3.27 instead of the on-image default.
+    environment:
+      BUNDLER_VERSION: 2.3.27
+
     steps:
       - checkout
       - run:
           name: install dependencies
           command: |
-            # The circleci/ruby:2.4.1 image ships Bundler 1.15.4, but the
-            # gemspec requires bundler ~> 2.3.7. Install the required version
-            # before running bundle install.
-            gem install bundler -v '~> 2.3.7' --no-document
-            bundle _2.3.27_ install --jobs=4 --retry=3 --path vendor/bundle
+            gem install bundler -v 2.3.27 --no-document
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
 
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,7 +13,11 @@ jobs:
       - run:
           name: install dependencies
           command: |
-            bundle install --jobs=4 --retry=3 --path vendor/bundle
+            # The circleci/ruby:2.4.1 image ships Bundler 1.15.4, but the
+            # gemspec requires bundler ~> 2.3.7. Install the required version
+            # before running bundle install.
+            gem install bundler -v '~> 2.3.7' --no-document
+            bundle _2.3.27_ install --jobs=4 --retry=3 --path vendor/bundle
 
       - run:
           name: Setup Code Climate test-reporter

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,13 @@
 # frozen_string_literal: true
 source 'https://rubygems.org'
 
+# Pin rack < 3 because rack 3+ requires Ruby 3+, but this gem targets
+# Ruby 2.4 (CircleCI image: circleci/ruby:2.4.1). httpi pulls rack as a
+# transitive dependency without a version constraint, so without this
+# pin bundler resolves to rack 3.x and CI specs fail to load with
+# `TypeError: wrong element type String at 0 (expected array)` from
+# `Rack::Utils#to_h`.
+gem 'rack', '< 3'
+
 # Specify your gem's dependencies in agris.gemspec
 gemspec

--- a/lib/agris/version.rb
+++ b/lib/agris/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Agris
-  VERSION = '0.19.0'
+  VERSION = '0.20.0'
 end


### PR DESCRIPTION
## Summary
The CircleCI build has been red on every recent PR (and on master itself). Two stacked breakages plus a transitive-dep regression had taken the pipeline down. This PR fixes all three and bumps the version so the next tag off master is **v0.20.0**.

## Fixes (all in `.circleci/config.yml` + `Gemfile`)

1. **Bundler version mismatch.** `circleci/ruby:2.4.1` ships Bundler `1.15.4`, but `agris.gemspec` requires `bundler ~> 2.3.7`. Install bundler 2.3.27 explicitly and set `BUNDLER_VERSION=2.3.27` at job scope so every `bundle` call across every step resolves to the right version.
2. **Dead Code Climate integration.** The `cc-test-reporter` download URL now serves an HTML 404 page; piping that through `./cc-test-reporter before-build` failed with shell syntax errors. Removed both the setup step and the before/after-build hooks. SimpleCov still produces coverage locally.
3. **Rack 3 transitive break.** `httpi` pulls `rack` without a version pin; bundler resolves to `rack 3.2.6`, which requires Ruby 3+. The repo targets Ruby 2.4. Added `gem 'rack', '< 3'` to the Gemfile (dev-only constraint, not propagated to consumers via the gemspec).

## Version bump

Bumps `lib/agris/version.rb` from `0.19.0` to `0.20.0` so the next tag off master is `v0.20.0`. Subsequent feature PRs (e.g. **VF-247 disbursements**, PR #40) merge into `0.20.0` without a second bump — they'll need to drop their own version.rb change during rebase.

## Why split out from VF-247 (PR #40)
Keeps PR #40 focused on the disbursement feature; this CI fix unblocks every other open and future PR too.

## Verified
- ✅ CircleCI build #172 — `install dependencies` succeeds, `run tests` runs rspec, job exits 0.
- ✅ Local: `bundle exec rspec` — 35 examples (master baseline) green under Ruby 2.5.9 with the rack pin.

## Branch protection note
Master's branch protection still requires two contexts that no provider publishes:
- `ci/circleci` (CircleCI actually publishes `ci/circleci: build`)
- `codeclimate` (integration is wound down)

Update the protection rule (Settings → Branches → master) to require `ci/circleci: build` and drop `codeclimate` so this PR is mergeable.